### PR TITLE
Indent shell snippets in README with 4 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ sha1-sat -- SAT instance generator for SHA-1
 To compile, you first need to make sure you have the Boost libraries
 installed. When you do, simply run make.sh:
 
-> bash make.sh
+    bash make.sh
 
 
 # Running
@@ -17,22 +17,22 @@ espresso is used to minimise the truth tables for the pseudo-boolean
 constraints used to encode the adders. You can obtain espresso from
 <ftp://ftp.cs.man.ac.uk/pub/amulet/balsa/other-software/espresso-ab-1.0.tar.gz>.
 
-> wget ftp://ftp.cs.man.ac.uk/pub/amulet/balsa/other-software/espresso-ab-1.0.tar.gz
-> tar xzvf espresso-ab-1.0.tar.gz
-> cd espresso-ab-1.0
-> ./configure
-> make
-> cd ..
-> export PATH="$PWD/espresso-ab-1.0/src:$PATH"
+    wget ftp://ftp.cs.man.ac.uk/pub/amulet/balsa/other-software/espresso-ab-1.0.tar.gz
+    tar xzvf espresso-ab-1.0.tar.gz
+    cd espresso-ab-1.0
+    ./configure
+    make
+    cd ..
+    export PATH="$PWD/espresso-ab-1.0/src:$PATH"
 
 To generate a CNF instance encoding a preimage attack on the full SHA-1
 algorithm, run:
 
-> ./main --cnf --rounds=80 --hash-bits=160 > instance.cnf
+    ./main --cnf --rounds=80 --hash-bits=160 > instance.cnf
 
 To look at the possible options, run:
 
-> ./main --help
+    ./main --help
 
 The program can also generate OPB instances (pseudo-boolean constraints) if
 you specify --opb instead of --cnf.
@@ -42,7 +42,7 @@ you specify --opb instead of --cnf.
 
 To verify that the solution output by the solver is actually correct, run:
 
-> perl verify-preimage instance.cnf solution | ./verify-preimage
+    perl verify-preimage instance.cnf solution | ./verify-preimage
 
 Here, 'solution' is the file output e.g. by minisat or the 'v'-line for
 other popular solvers like CryptoMiniSAT or PrecoSAT. The program returns


### PR DESCRIPTION
This way Markdown formatters will render the snippets as code blocks.